### PR TITLE
podman: moved settings under config

### DIFF
--- a/tests/modules/services/podman-linux/configuration.nix
+++ b/tests/modules/services/podman-linux/configuration.nix
@@ -3,33 +3,35 @@
 {
   services.podman = {
     enable = true;
-    containersConf.settings = {
-      network = {
-        default_subnet = "172.16.10.0/24";
-        default_subnet_pools = [
-          {
-            base = "172.16.11.0/24";
-            size = 24;
-          }
-          {
-            base = "172.16.12.0/24";
-            size = 24;
-          }
-        ];
+    config = {
+      containers.settings = {
+        network = {
+          default_subnet = "172.16.10.0/24";
+          default_subnet_pools = [
+            {
+              base = "172.16.11.0/24";
+              size = 24;
+            }
+            {
+              base = "172.16.12.0/24";
+              size = 24;
+            }
+          ];
+        };
       };
-    };
-    storage.settings = {
-      storage = {
-        runroot = "$HOME/.containers/runroot";
-        graphroot = "$HOME/.containers/graphroot";
+      storage.settings = {
+        storage = {
+          runroot = "$HOME/.containers/runroot";
+          graphroot = "$HOME/.containers/graphroot";
+        };
       };
+      registries = {
+        block = [ "ghcr.io" "gallery.ecr.aws" ];
+        insecure = [ "quay.io" ];
+        search = [ "docker.io" ];
+      };
+      policy = { default = [{ type = "insecureAcceptAnything"; }]; };
     };
-    registries = {
-      block = [ "ghcr.io" "gallery.ecr.aws" ];
-      insecure = [ "quay.io" ];
-      search = [ "docker.io" ];
-    };
-    policy = { default = [{ type = "insecureAcceptAnything"; }]; };
   };
 
   nmt.script = ''


### PR DESCRIPTION
### Description

I moved the newly added configurations under services.podman.config and updated tests.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).